### PR TITLE
Fix: 시간 누락 문제로 인한 날짜 비교 오류 수정

### DIFF
--- a/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestion.java
+++ b/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestion.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "daily_question")
@@ -21,10 +21,10 @@ public class DailyQuestion {
     private String question;
 
     @Column(nullable = false, unique = true)
-    private LocalDate date;
+    private LocalDateTime date;
 
     @Builder
-    public DailyQuestion(String question, LocalDate date) {
+    public DailyQuestion(String question, LocalDateTime date) {
         this.question = question;
         this.date = date;
     }

--- a/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestionController.java
+++ b/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestionController.java
@@ -60,3 +60,4 @@ public class DailyQuestionController {
 }
 
 
+

--- a/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestionDto.java
+++ b/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestionDto.java
@@ -1,5 +1,6 @@
 package goormthonuniv.swu.starcapsule.dailyQuestion;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Data;
 
@@ -10,13 +11,14 @@ import java.time.LocalDateTime;
 public class DailyQuestionDto {
     private Long id;
     private String question;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime date;
 
     public static DailyQuestionDto fromEntity(DailyQuestion dailyQuestion) {
         return DailyQuestionDto.builder()
                 .id(dailyQuestion.getId())
                 .question(dailyQuestion.getQuestion())
-                .date(dailyQuestion.getDate().atStartOfDay())
+                .date(dailyQuestion.getDate())
                 .build();
     }
 }

--- a/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestionRepository.java
+++ b/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestionRepository.java
@@ -2,11 +2,9 @@ package goormthonuniv.swu.starcapsule.dailyQuestion;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface DailyQuestionRepository extends JpaRepository<DailyQuestion ,Long> {
-    Optional<DailyQuestion> findByDate(LocalDate date);
-
+    Optional<DailyQuestion> findByDate(LocalDateTime date);
 }

--- a/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestionService.java
+++ b/src/main/java/goormthonuniv/swu/starcapsule/dailyQuestion/DailyQuestionService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
 
@@ -15,8 +16,7 @@ public class DailyQuestionService {
 
     // 오늘 날짜에 해당하는 질문을 가져옵니다.
     public Optional<DailyQuestion> getTodayQuestion() {
-        LocalDate today = LocalDate.now();
-        return dailyQuestionRepository.findByDate(today);
+        LocalDateTime todayStartOfDay = LocalDate.now().atStartOfDay();
+        return dailyQuestionRepository.findByDate(todayStartOfDay);
     }
-
 }


### PR DESCRIPTION
daily_question 테이블에서 date 컬럼이 LocalDate 타입으로 설정되어 있어 시간 정보가 누락되었습니다. 이로 인해 날짜 비교와 관련된 기능에서 정확한 결과를 얻지 못하는 문제가 발생했습니다.

DB 수정: daily_question 테이블의 date 컬럼을 DATETIME 타입으로 변경하여 날짜와 시간 정보를 모두 포함하도록 수정했습니다.
쿼리 수정: 날짜와 시간을 모두 포함할 수 있도록 UPDATE 쿼리를 수정하여, 
date 컬럼에 YYYY-MM-DD HH:mm:ss 형식으로 값을 저장하도록 했습니다.

DTO 수정: DailyQuestionDto에서 LocalDateTime을 사용하여, 날짜와 시간 정보가 포함된 값을 반환하도록 수정했습니다.
기타: 해당 변경사항으로 날짜 비교와 조회에서 정확한 결과를 얻을 수 있게 되었습니다. 시간 정보가 추가되어 관련 기능들이 정상 작동하게 되었습니다.

Closes #101 